### PR TITLE
add remaining FirebaseAnalytics API

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -30,7 +30,7 @@ android {
         disable 'InvalidPackage'
     }
     dependencies {
-        compile 'com.google.firebase:firebase-auth:9.0.0'
-        compile 'com.google.firebase:firebase-analytics:9.0.0'
+        compile 'com.google.firebase:firebase-auth:10.2.1'
+        compile 'com.google.firebase:firebase-analytics:10.2.1'
     }
 }

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -4,4 +4,7 @@
   android:versionName="0.0.1">
 
   <uses-sdk android:minSdkVersion="16" android:targetSdkVersion="21" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+  <uses-permission android:name="android.permission.INTERNET" />
+  <uses-permission android:name="android.permission.WAKE_LOCK" />
 </manifest>

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -4,7 +4,8 @@
   android:versionName="0.0.1">
 
   <uses-sdk android:minSdkVersion="16" android:targetSdkVersion="21" />
-    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+
+  <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
   <uses-permission android:name="android.permission.INTERNET" />
   <uses-permission android:name="android.permission.WAKE_LOCK" />
 </manifest>

--- a/android/src/main/java/io/flutter/firebase_analytics/FirebaseAnalyticsPlugin.java
+++ b/android/src/main/java/io/flutter/firebase_analytics/FirebaseAnalyticsPlugin.java
@@ -19,6 +19,7 @@ import io.flutter.plugin.common.MethodCall;
  * Flutter plugin for Firebase Analytics.
  */
 public class FirebaseAnalyticsPlugin implements MethodCallHandler {
+  private final FlutterActivity activity;
   private final FirebaseAnalytics firebaseAnalytics;
 
   public static FirebaseAnalyticsPlugin register(FlutterActivity activity) {
@@ -26,24 +27,94 @@ public class FirebaseAnalyticsPlugin implements MethodCallHandler {
   }
 
   private FirebaseAnalyticsPlugin(FlutterActivity activity) {
+    this.activity = activity;
     this.firebaseAnalytics = FirebaseAnalytics.getInstance(activity);
     new FlutterMethodChannel(activity.getFlutterView(), "firebase_analytics").setMethodCallHandler(this);
   }
 
   @Override
   public void onMethodCall(MethodCall call, Response response) {
-    if (call.method.equals("logEvent")) {
-      @SuppressWarnings("unchecked")
-      Map<String, Object> arguments = (Map<String, Object>) call.arguments;
-      final String eventName = (String) arguments.get("name");
-
-      @SuppressWarnings("unchecked")
-      final Bundle parameterBundle = createBundleFromMap((Map<String, Object>) arguments.get("parameters"));
-      firebaseAnalytics.logEvent(eventName, parameterBundle);
-      response.success(null);
-    } else {
-      response.notImplemented();
+    switch (call.method) {
+      case "logEvent":
+        handleLogEvent(call, response);
+        break;
+      case "setUserId":
+        handleSetUserId(call, response);
+        break;
+      case "setCurrentScreen":
+        handleSetCurrentScreen(call, response);
+        break;
+      case "setAnalyticsCollectionEnabled":
+        handleSetAnalyticsCollectionEnabled(call, response);
+        break;
+      case "setMinimumSessionDuration":
+        handleSetMinimumSessionDuration(call, response);
+        break;
+      case "setSessionTimeoutDuration":
+        handleSetSessionTimeoutDuration(call, response);
+        break;
+      case "setUserProperty":
+        handleSetUserProperty(call, response);
+        break;
+      default:
+        response.notImplemented();
+        break;
     }
+  }
+
+  private void handleLogEvent(MethodCall call, Response response) {
+    @SuppressWarnings("unchecked")
+    Map<String, Object> arguments = (Map<String, Object>) call.arguments;
+    final String eventName = (String) arguments.get("name");
+
+    @SuppressWarnings("unchecked")
+    final Bundle parameterBundle = createBundleFromMap((Map<String, Object>) arguments.get("parameters"));
+    firebaseAnalytics.logEvent(eventName, parameterBundle);
+    response.success(null);
+  }
+
+  private void handleSetUserId(MethodCall call, Response response) {
+    final String id = (String) call.arguments;
+    firebaseAnalytics.setUserId(id);
+    response.success(null);
+  }
+
+  private void handleSetCurrentScreen(MethodCall call, Response response) {
+    @SuppressWarnings("unchecked")
+    Map<String, Object> arguments = (Map<String, Object>) call.arguments;
+    final String screenName = (String) arguments.get("screenName");
+    final String screenClassOverride = (String) arguments.get("screenClassOverride");
+
+    firebaseAnalytics.setCurrentScreen(activity, screenName, screenClassOverride);
+    response.success(null);
+  }
+
+  private void handleSetAnalyticsCollectionEnabled(MethodCall call, Response response) {
+    final Boolean enabled = (Boolean) call.arguments;
+    firebaseAnalytics.setAnalyticsCollectionEnabled(enabled);
+    response.success(null);
+  }
+
+  private void handleSetMinimumSessionDuration(MethodCall call, Response response) {
+    final Integer milliseconds = (Integer) call.arguments;
+    firebaseAnalytics.setMinimumSessionDuration(milliseconds);
+    response.success(null);
+  }
+
+  private void handleSetSessionTimeoutDuration(MethodCall call, Response response) {
+    final Integer milliseconds = (Integer) call.arguments;
+    firebaseAnalytics.setSessionTimeoutDuration(milliseconds);
+    response.success(null);
+  }
+
+  private void handleSetUserProperty(MethodCall call, Response response) {
+    @SuppressWarnings("unchecked")
+    Map<String, Object> arguments = (Map<String, Object>) call.arguments;
+    final String name = (String) arguments.get("name");
+    final String value = (String) arguments.get("value");
+
+    firebaseAnalytics.setUserProperty(name, value);
+    response.success(null);
   }
 
   private static Bundle createBundleFromMap(Map<String, Object> map) {

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -37,17 +37,49 @@ class _MyHomePageState extends State<MyHomePage> {
   String _message = '';
   final FirebaseAnalytics analytics = new FirebaseAnalytics();
 
-  void _sendAnalyticsEvent() {
-    analytics.logEvent(name: 'test_event').then((_) async {
-      setState(() {
-        _message = 'Analytics event sent successfully';
-      });
-
-      await new Future.delayed(const Duration(seconds: 1));
-      setState(() {
-        _message = '';
-      });
+  void setMessage(String message) {
+    setState(() {
+      _message = message;
     });
+  }
+
+  Future<Null> _sendAnalyticsEvent() async {
+    await analytics.logEvent(name: 'test_event');
+    setMessage('logEvent succeeded');
+  }
+
+  Future<Null> _testSetUserId() async {
+    await analytics.setUserId('some-user');
+    setMessage('setUserId succeeded');
+  }
+
+  Future<Null> _testSetCurrentScreen() async {
+    await analytics.setCurrentScreen(
+      screenName: 'Analytics Demo',
+      screenClassOverride: 'AnalyticsDemo',
+    );
+    setMessage('setCurrentScreen succeeded');
+  }
+
+  Future<Null> _testSetAnalyticsCollectionEnabled() async {
+    await analytics.setAnalyticsCollectionEnabled(false);
+    await analytics.setAnalyticsCollectionEnabled(true);
+    setMessage('setAnalyticsCollectionEnabled succeeded');
+  }
+
+  Future<Null> _testSetMinimumSessionDuration() async {
+    await analytics.setMinimumSessionDuration(20000);
+    setMessage('setMinimumSessionDuration succeeded');
+  }
+
+  Future<Null> _testSetSessionTimeoutDuration() async {
+    await analytics.setSessionTimeoutDuration(2000000);
+    setMessage('setSessionTimeoutDuration succeeded');
+  }
+
+  Future<Null> _testSetUserProperty() async {
+    await analytics.setUserProperty('regular', 'indeed');
+    setMessage('setUserProperty succeeded');
   }
 
   Future<Null> _testAllEventTypes() async {
@@ -208,6 +240,7 @@ class _MyHomePageState extends State<MyHomePage> {
     await analytics.logViewSearchResults(
       searchTerm: 'test search term',
     );
+    setMessage('All standard events logged successfully');
   }
 
   @override
@@ -218,22 +251,40 @@ class _MyHomePageState extends State<MyHomePage> {
       ),
       body: new Column(
         children: <Widget>[
-          new Column(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              new Text(_message),
-            ],
+          new MaterialButton(
+            child: const Text('Test logEvent'),
+            onPressed: _sendAnalyticsEvent,
           ),
           new MaterialButton(
-            child: const Text('Test all event types'),
+            child: const Text('Test standard event types'),
             onPressed: _testAllEventTypes,
           ),
+          new MaterialButton(
+            child: const Text('Test setUserId'),
+            onPressed: _testSetUserId,
+          ),
+          new MaterialButton(
+            child: const Text('Test setCurrentScreen'),
+            onPressed: _testSetCurrentScreen,
+          ),
+          new MaterialButton(
+            child: const Text('Test setAnalyticsCollectionEnabled'),
+            onPressed: _testSetAnalyticsCollectionEnabled,
+          ),
+          new MaterialButton(
+            child: const Text('Test setMinimumSessionDuration'),
+            onPressed: _testSetMinimumSessionDuration,
+          ),
+          new MaterialButton(
+            child: const Text('Test setSessionTimeoutDuration'),
+            onPressed: _testSetSessionTimeoutDuration,
+          ),
+          new MaterialButton(
+            child: const Text('Test setUserProperty'),
+            onPressed: _testSetUserProperty,
+          ),
+          new Text(_message, style: const TextStyle(color: const Color.fromARGB(255, 0, 155, 0))),
         ],
-      ),
-      floatingActionButton: new FloatingActionButton(
-        onPressed: _sendAnalyticsEvent,
-        tooltip: 'Send Analytics Event',
-        child: new Icon(Icons.add),
       ),
     );
   }

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -62,18 +62,18 @@ class _MyHomePageState extends State<MyHomePage> {
   }
 
   Future<Null> _testSetAnalyticsCollectionEnabled() async {
-    await analytics.android.setAnalyticsCollectionEnabled(false);
-    await analytics.android.setAnalyticsCollectionEnabled(true);
+    await analytics.android?.setAnalyticsCollectionEnabled(false);
+    await analytics.android?.setAnalyticsCollectionEnabled(true);
     setMessage('setAnalyticsCollectionEnabled succeeded');
   }
 
   Future<Null> _testSetMinimumSessionDuration() async {
-    await analytics.android.setMinimumSessionDuration(20000);
+    await analytics.android?.setMinimumSessionDuration(20000);
     setMessage('setMinimumSessionDuration succeeded');
   }
 
   Future<Null> _testSetSessionTimeoutDuration() async {
-    await analytics.android.setSessionTimeoutDuration(2000000);
+    await analytics.android?.setSessionTimeoutDuration(2000000);
     setMessage('setSessionTimeoutDuration succeeded');
   }
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -62,23 +62,23 @@ class _MyHomePageState extends State<MyHomePage> {
   }
 
   Future<Null> _testSetAnalyticsCollectionEnabled() async {
-    await analytics.setAnalyticsCollectionEnabled(false);
-    await analytics.setAnalyticsCollectionEnabled(true);
+    await analytics.android.setAnalyticsCollectionEnabled(false);
+    await analytics.android.setAnalyticsCollectionEnabled(true);
     setMessage('setAnalyticsCollectionEnabled succeeded');
   }
 
   Future<Null> _testSetMinimumSessionDuration() async {
-    await analytics.setMinimumSessionDuration(20000);
+    await analytics.android.setMinimumSessionDuration(20000);
     setMessage('setMinimumSessionDuration succeeded');
   }
 
   Future<Null> _testSetSessionTimeoutDuration() async {
-    await analytics.setSessionTimeoutDuration(2000000);
+    await analytics.android.setSessionTimeoutDuration(2000000);
     setMessage('setSessionTimeoutDuration succeeded');
   }
 
   Future<Null> _testSetUserProperty() async {
-    await analytics.setUserProperty('regular', 'indeed');
+    await analytics.setUserProperty(name: 'regular', value: 'indeed');
     setMessage('setUserProperty succeeded');
   }
 

--- a/ios/Classes/FirebaseAnalyticsPlugin.m
+++ b/ios/Classes/FirebaseAnalyticsPlugin.m
@@ -33,6 +33,20 @@
         }
 
         result(nil);
+      } else if ([@"setUserId" isEqualToString:call.method]) {
+        NSString *userId = call.arguments;
+        [FIRAnalytics setUserID:userId];
+        result(nil);
+      } else if ([@"setCurrentScreen" isEqualToString:call.method]) {
+        NSString *screenName = call.arguments[@"screenName"];
+        NSString *screenClassOverride = call.arguments[@"screenClassOverride"];
+        [FIRAnalytics setScreenName:screenName screenClass:screenClassOverride];
+        result(nil);
+      } else if ([@"setUserProperty" isEqualToString:call.method]) {
+        NSString *name = call.arguments[@"name"];
+        NSString *value = call.arguments[@"value"];
+        [FIRAnalytics setUserPropertyString:value forName:name];
+        result(nil);
       } else {
         NSString *message = [NSString stringWithFormat:@"Method not implemented: %@", call.method];
         result([FlutterError errorWithCode:message

--- a/lib/firebase_analytics.dart
+++ b/lib/firebase_analytics.dart
@@ -7,6 +7,7 @@ import 'dart:async';
 import 'package:meta/meta.dart';
 
 import 'package:flutter/services.dart';
+import 'package:flutter/foundation.dart';
 
 /// Firebase Analytics API.
 class FirebaseAnalytics {
@@ -20,13 +21,23 @@ class FirebaseAnalytics {
   @visibleForTesting
   FirebaseAnalytics.private(PlatformMethodChannel platformChannel)
     : _channel = platformChannel,
-      _androidApi = new FirebaseAnalyticsAndroid.private(platformChannel);
+      android = defaultTargetPlatform == TargetPlatform.android
+        ? new FirebaseAnalyticsAndroid.private(platformChannel)
+        : null;
 
   final PlatformMethodChannel _channel;
-  final FirebaseAnalyticsAndroid _androidApi;
 
   /// Namespace for analytics API available on Android only.
-  FirebaseAnalyticsAndroid get android => _androidApi;
+  ///
+  /// The value of this field is `null` on non-Android platforms. If you are
+  /// writing cross-platform code, consider using null-aware operator when
+  /// accessing it.
+  ///
+  /// Example:
+  ///
+  ///     FirebaseAnalytics analytics = new FirebaseAnalytics();
+  ///     analytics.android?.setMinimumSessionDuration(200000);
+  final FirebaseAnalyticsAndroid android;
 
   /// Logs a custom Flutter Analytics event with the given [name] and event [parameters].
   Future<Null> logEvent({@required String name, Map<String, dynamic> parameters}) async {

--- a/lib/firebase_analytics.dart
+++ b/lib/firebase_analytics.dart
@@ -41,6 +41,103 @@ class FirebaseAnalytics {
     });
   }
 
+  /// Sets the user ID property.
+  ///
+  /// This feature must be used in accordance with [Google's Privacy Policy][1].
+  ///
+  /// [1](https://www.google.com/policies/privacy/)
+  Future<Null> setUserId(String id) async {
+    if (id == null)
+      throw new ArgumentError.notNull('id');
+
+    await _channel.invokeMethod('setUserId', id);
+  }
+
+  /// Sets the current [screenName], which specifies the current visual context
+  /// in your app.
+  ///
+  /// This helps identify the areas in your app where users spend their time
+  /// and how they interact with your app.
+  ///
+  /// The class name can optionally be overridden by the [screenClassOverride]
+  /// parameter.
+  ///
+  /// The [screenName] and [screenClassOverride] remain in effect until the
+  /// current `Activity` (in Android) or `UIViewController` (in iOS) changes or
+  /// a new call to [setCurrentScreen] is made.
+  ///
+  /// See also:
+  ///
+  /// https://firebase.google.com/docs/reference/android/com/google/firebase/analytics/FirebaseAnalytics.html#setCurrentScreen(android.app.Activity, java.lang.String, java.lang.String)
+  /// https://firebase.google.com/docs/reference/ios/firebaseanalytics/api/reference/Classes/FIRAnalytics#setscreennamescreenclass
+  Future<Null> setCurrentScreen({@required String screenName, String screenClassOverride}) async {
+    if (screenName == null)
+      throw new ArgumentError.notNull('screenName');
+
+    await _channel.invokeMethod('setCurrentScreen', <String, String>{
+      'screenName': screenName,
+      'screenClassOverride': screenClassOverride,
+    });
+  }
+
+  /// Sets whether analytics collection is enabled for this app on this device.
+  ///
+  /// This setting is persisted across app sessions. By default it is enabled.
+  Future<Null> setAnalyticsCollectionEnabled(bool enabled) async {
+    if (enabled == null)
+      throw new ArgumentError.notNull('enabled');
+
+    await _channel.invokeMethod('setAnalyticsCollectionEnabled', enabled);
+  }
+
+  /// Sets the minimum engagement time required before starting a session.
+  ///
+  /// The default value is 10000 (10 seconds).
+  Future<Null> setMinimumSessionDuration(int milliseconds) async {
+    if (milliseconds == null)
+      throw new ArgumentError.notNull('milliseconds');
+
+    await _channel.invokeMethod('setMinimumSessionDuration', milliseconds);
+  }
+
+  /// Sets the duration of inactivity that terminates the current session.
+  ///
+  /// The default value is 1800000 (30 minutes).
+  Future<Null> setSessionTimeoutDuration(int milliseconds) async {
+    if (milliseconds == null)
+      throw new ArgumentError.notNull('milliseconds');
+
+    await _channel.invokeMethod('setSessionTimeoutDuration', milliseconds);
+  }
+
+  static final RegExp _nonAlphaNumeric = new RegExp(r'[^a-zA-Z0-9_]');
+  static final RegExp _alpha = new RegExp(r'[a-zA-Z]');
+
+  /// Sets a user property to a given value.
+  ///
+  /// Up to 25 user property names are supported. Once set, user property
+  /// values persist throughout the app lifecycle and across sessions.
+  ///
+  /// [name] is the name of the user property to set. Should contain 1 to 24
+  /// alphanumeric characters or underscores and must start with an alphabetic
+  /// character. The "firebase_" prefix is reserved and should not be used for
+  /// user property names.
+  Future<Null> setUserProperty(String name, String value) async {
+    if (name == null)
+      throw new ArgumentError.notNull('name');
+
+    if (name.isEmpty || name.length > 24 || name.indexOf(_alpha) != 0 || name.contains(_nonAlphaNumeric))
+      throw new ArgumentError.value(name, 'name', 'must contain 1 to 24 alphanumeric characters.');
+
+    if (name.startsWith('firebase_'))
+      throw new ArgumentError.value(name, 'name', '"firebase_" prefix is reserved');
+
+    await _channel.invokeMethod('setUserProperty', <String, String>{
+      'name': name,
+      'value': value,
+    });
+  }
+
   /// Logs the standard `add_payment_info` event.
   ///
   /// This event signifies that a user has submitted their payment information

--- a/lib/firebase_analytics.dart
+++ b/lib/firebase_analytics.dart
@@ -52,7 +52,7 @@ class FirebaseAnalytics {
   ///
   /// This feature must be used in accordance with [Google's Privacy Policy][1].
   ///
-  /// [1](https://www.google.com/policies/privacy/)
+  /// [1]: https://www.google.com/policies/privacy/
   Future<Null> setUserId(String id) async {
     if (id == null)
       throw new ArgumentError.notNull('id');

--- a/test/firebase_analytics_test.dart
+++ b/test/firebase_analytics_test.dart
@@ -26,6 +26,82 @@ void main() {
   group('$FirebaseAnalytics', () {
     FirebaseAnalytics analytics;
 
+    String invokedMethod;
+    dynamic arguments;
+
+    setUp(() {
+      MockPlatformChannel mockChannel = new MockPlatformChannel();
+
+      invokedMethod = null;
+      arguments = null;
+
+      when(mockChannel.invokeMethod(any, any)).thenAnswer((Invocation invocation) {
+        invokedMethod = invocation.positionalArguments[0];
+        arguments = invocation.positionalArguments[1];
+      });
+
+      analytics = new FirebaseAnalytics.private(mockChannel);
+    });
+
+    test('setUserId', () async {
+      await analytics.setUserId('test-user-id');
+      expect(invokedMethod, 'setUserId');
+      expect(arguments, 'test-user-id');
+    });
+
+    test('setCurrentScreen', () async {
+      await analytics.setCurrentScreen(screenName: 'test-screen-name', screenClassOverride: 'test-class-override');
+      expect(invokedMethod, 'setCurrentScreen');
+      expect(arguments, <String, String>{
+        'screenName': 'test-screen-name',
+        'screenClassOverride': 'test-class-override',
+      });
+    });
+
+    test('setUserProperty', () async {
+      await analytics.setUserProperty(name: 'test_name', value: 'test-value');
+      expect(invokedMethod, 'setUserProperty');
+      expect(arguments, <String, String>{
+        'name': 'test_name',
+        'value': 'test-value',
+      });
+    });
+
+    test('setUserProperty rejects invalid names', () async {
+      // invalid character
+      expect(analytics.setUserProperty(name: 'test-name', value: 'test-value'), throwsArgumentError);
+      // non-alpha first character
+      expect(analytics.setUserProperty(name: '0test', value: 'test-value'), throwsArgumentError);
+      // null
+      expect(analytics.setUserProperty(name: null, value: 'test-value'), throwsArgumentError);
+      // blank
+      expect(analytics.setUserProperty(name: '', value: 'test-value'), throwsArgumentError);
+      // reserved prefix
+      expect(analytics.setUserProperty(name: 'firebase_test', value: 'test-value'), throwsArgumentError);
+    });
+
+    test('setAnalyticsCollectionEnabled', () async {
+      await analytics.android.setAnalyticsCollectionEnabled(false);
+      expect(invokedMethod, 'setAnalyticsCollectionEnabled');
+      expect(arguments, false);
+    });
+
+    test('setMinimumSessionDuration', () async {
+      await analytics.android.setMinimumSessionDuration(123);
+      expect(invokedMethod, 'setMinimumSessionDuration');
+      expect(arguments, 123);
+    });
+
+    test('setSessionTimeoutDuration', () async {
+      await analytics.android.setSessionTimeoutDuration(234);
+      expect(invokedMethod, 'setSessionTimeoutDuration');
+      expect(arguments, 234);
+    });
+  });
+
+  group('$FirebaseAnalytics analytics events', () {
+    FirebaseAnalytics analytics;
+
     String name;
     Map<String, dynamic> parameters;
 


### PR DESCRIPTION
Add the following methods from the FirebaseAnalytics class:

- `setUserId`
- `setCurrentScreen` (which required version bump)
- `setUserProperty`

The following are Android-only:

- `setAnalyticsCollectionEnabled`
- `setMinimumSessionDuration`
- `setSessionTimeoutDuration`

Fixes https://github.com/flutter/flutter/issues/5497